### PR TITLE
Pipe 'error' event from content to output stream

### DIFF
--- a/src/buildmail.js
+++ b/src/buildmail.js
@@ -356,6 +356,11 @@ MimeNode.prototype.build = function(callback) {
     var stream = this.createReadStream();
     var buf = [];
     var buflen = 0;
+    var calledBack;
+    var callbackOnce = function () {
+        calledBack || callback.apply(this, arguments);
+        calledBack = true;
+    };
 
     stream.on('data', function(chunk) {
         if (chunk && chunk.length) {
@@ -364,12 +369,14 @@ MimeNode.prototype.build = function(callback) {
         }
     });
 
+    stream.once('error', callbackOnce);
+
     stream.once('end', function(chunk) {
         if (chunk && chunk.length) {
             buf.push(chunk);
             buflen += chunk.length;
         }
-        return callback(null, Buffer.concat(buf, buflen));
+        return callbackOnce(null, Buffer.concat(buf, buflen));
     });
 };
 

--- a/src/buildmail.js
+++ b/src/buildmail.js
@@ -531,20 +531,6 @@ MimeNode.prototype.stream = function(outputStream, options, callback) {
     function sendContent() {
         if (_self.content) {
 
-            if (typeof _self.content.pipe === 'function') {
-                _self.content.removeListener('error', _self._contentErrorHandler);
-                _self._contentErrorHandler = function(err) {
-                    if (contentStream) {
-                        contentStream.write('<' + err.message + '>');
-                        contentStream.end();
-                    } else {
-                        outputStream.write('<' + err.message + '>');
-                        setImmediate(finalize);
-                    }
-                };
-                _self.content.once('error', _self._contentErrorHandler);
-            }
-
             if (['quoted-printable', 'base64'].indexOf(transferEncoding) >= 0) {
                 contentStream = new(transferEncoding === 'base64' ? libbase64 : libqp).Encoder(options);
 

--- a/src/buildmail.js
+++ b/src/buildmail.js
@@ -546,6 +546,7 @@ MimeNode.prototype.stream = function(outputStream, options, callback) {
             // throw when `once('error')` is used and an error occurs
             localStream.on('error', function(err) {
                 contentStream.end('[' + err.message + ']');
+                outputStream.emit('error', err);
             });
             localStream.pipe(contentStream);
         } else {
@@ -562,6 +563,7 @@ MimeNode.prototype.stream = function(outputStream, options, callback) {
             // throw when `once('error')` is used and an error occurs
             localStream.on('error', function(err) {
                 outputStream.write('[' + err.message + ']');
+                outputStream.emit('error', err);
                 finalize();
             });
         }

--- a/src/buildmail.js
+++ b/src/buildmail.js
@@ -560,7 +560,7 @@ MimeNode.prototype.stream = function(outputStream, options, callback) {
                 // using `on` instead of `once` because hyperquest 0.3.0 seems to
                 // throw when `once('error')` is used and an error occurs
                 localStream.on('error', function(err) {
-                    localStream.write('[' + err.message + ']');
+                    outputStream.write('[' + err.message + ']');
                     finalize();
                 });
                 return;

--- a/src/buildmail.js
+++ b/src/buildmail.js
@@ -529,44 +529,41 @@ MimeNode.prototype.stream = function(outputStream, options, callback) {
 
     // pushes node content
     function sendContent() {
-        if (_self.content) {
-
-            if (['quoted-printable', 'base64'].indexOf(transferEncoding) >= 0) {
-                contentStream = new(transferEncoding === 'base64' ? libbase64 : libqp).Encoder(options);
-
-                contentStream.pipe(outputStream, {
-                    end: false
-                });
-                contentStream.once('end', finalize);
-
-                localStream = _self._getStream(_self.content);
-                // using `on` instead of `once` because hyperquest 0.3.0 seems to
-                // throw when `once('error')` is used and an error occurs
-                localStream.on('error', function(err) {
-                    contentStream.end('[' + err.message + ']');
-                });
-                localStream.pipe(contentStream);
-                return;
-            } else {
-                if (_self._isFlowedContent) {
-                    localStream = _self._getStream(libmime.encodeFlowed(_self.content));
-                } else {
-                    localStream = _self._getStream(_self.content);
-                }
-                localStream.pipe(outputStream, {
-                    end: false
-                });
-                localStream.once('end', finalize);
-                // using `on` instead of `once` because hyperquest 0.3.0 seems to
-                // throw when `once('error')` is used and an error occurs
-                localStream.on('error', function(err) {
-                    outputStream.write('[' + err.message + ']');
-                    finalize();
-                });
-                return;
-            }
-        } else {
+        if (!_self.content) {
             return setImmediate(finalize);
+        }
+
+        if (['quoted-printable', 'base64'].indexOf(transferEncoding) >= 0) {
+            contentStream = new(transferEncoding === 'base64' ? libbase64 : libqp).Encoder(options);
+
+            contentStream.pipe(outputStream, {
+                end: false
+            });
+            contentStream.once('end', finalize);
+
+            localStream = _self._getStream(_self.content);
+            // using `on` instead of `once` because hyperquest 0.3.0 seems to
+            // throw when `once('error')` is used and an error occurs
+            localStream.on('error', function(err) {
+                contentStream.end('[' + err.message + ']');
+            });
+            localStream.pipe(contentStream);
+        } else {
+            if (_self._isFlowedContent) {
+                localStream = _self._getStream(libmime.encodeFlowed(_self.content));
+            } else {
+                localStream = _self._getStream(_self.content);
+            }
+            localStream.pipe(outputStream, {
+                end: false
+            });
+            localStream.once('end', finalize);
+            // using `on` instead of `once` because hyperquest 0.3.0 seems to
+            // throw when `once('error')` is used and an error occurs
+            localStream.on('error', function(err) {
+                outputStream.write('[' + err.message + ']');
+                finalize();
+            });
         }
     }
 

--- a/test/libbuildmail-unit.js
+++ b/test/libbuildmail-unit.js
@@ -917,14 +917,14 @@ describe('Buildmail', function() {
             });
         });
 
-        it('#should not throw on error', function(done) {
+        it('should not throw on error', function(done) {
             var mb = new Buildmail('text/plain').
             setContent({
                 href: 'http://__should_not_exist:88888'
             });
 
-            mb.build(function(err, msg) {
-                msg = msg.toString();
+            mb.build(function(err) {
+                var msg = err.toString();
                 expect(/ENOTFOUND/.test(msg)).to.be.true;
                 done();
             });

--- a/test/one-message-stream.js
+++ b/test/one-message-stream.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var Readable = require('stream').Readable;
+var util = require('util');
+util.inherits(OneMessageStream, Readable);
+
+/**
+ * A stream which emits one 'data' event with a supplied message.
+ * @param {String} message The data to be passed to the 'data' event
+ * @param {Error} error If passed, an 'error' event is triggered with it upon reading the stream.
+ */
+function OneMessageStream(message, error) {
+    var readOnce = false;
+    Readable.call(this);
+    this._read = function(){
+        if (!readOnce) {
+            this.push(message);
+            if (error) {
+                this.emit('error', error);
+            }
+            readOnce = true;
+        } else {
+            this.push(null);
+        }
+    };
+}
+
+module.exports = OneMessageStream;


### PR DESCRIPTION
Currently if the content stream triggers an 'error' event (this can happen for a number of reasons), users of Nodemailer have no means to be notified of this. This PR proxies 'error' event from the content stream to the output stream so that transports can themselves detect and handle this error.
I have removed some code that seemed duplicate and done (what seemed to me like) very minimal cleanup. The changes are atomic and broken down by commit.
A PR for each transport will follow shortly.