### PR TITLE
Downgrade to punycode v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "libqp": "1.1.0",
     "nodemailer-fetch": "1.6.0",
     "nodemailer-shared": "1.1.0",
-    "punycode": "^2.0.1"
+    "punycode": "^1.4.1"
   },
   "devDependencies": {
     "chai": "~3.5.0",


### PR DESCRIPTION
Punycode 2.0 only supports node >= 6. npm generates a warning if installed on an older version of node, and stricter dependency managers like yarn will fail unless you disable the engine check.

This is sort of an edge case since punycode won't even be used in node until the built in `punycode` module is removed, but downgrading does make it easier to install `buildmail`. 

`v1.4` is the [official supported version](https://github.com/bestiejs/punycode.js) if you want to support older node versions:
> The current version supports recent versions of Node.js only. It provides a CommonJS module and an ES6 module. For the old version that offers the same functionality with broader support, including Rhino, Ringo, Narwhal, and web browsers, see v1.4.1.